### PR TITLE
Improve build time by memoizing api calls

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,9 +6,13 @@ import { getDirectusClient } from "../utils/directus-client";
 import HomeLatestMeetup from "../components/HomeLatestMeetup.astro";
 
 const directus = await getDirectusClient();
-const response = await directus.items("Events").readByQuery({
+global.events = global.events
+    ? global.events
+    :  await directus.items("Events").readByQuery({
 	fields: ["*.*"],
 });
+
+let response = global.events
 ---
 
 <LayoutHome>

--- a/src/pages/meetup/[id].astro
+++ b/src/pages/meetup/[id].astro
@@ -6,41 +6,40 @@ import { getDirectusClient } from "../../utils/directus-client";
 const props = Astro.params;
 
 export async function getStaticPaths() {
-    const directus = await getDirectusClient();
-    const response = await directus.items("Events").readByQuery({
-    	fields: ["*.*"],
-    });    
+  const directus = await getDirectusClient();
+  global.events = global.events
+    ? global.events
+    : await directus.items("Events").readByQuery({
+        fields: ["*.*"],
+      });
 
-    return response.data.map((event) => {
-    	return { 
-            params: {
-                id: event.id.toString(),
-                		
-            },    	
-        };
-    });
+  return global.events.data.map((event) => {
+    return {
+      params: {
+        id: event.id.toString(),
+      },
+    };
+  });
 }
 
 // Get Data for the current meetup based on the id
 const directus = await getDirectusClient();
-const getCurrentMeetup = await directus.items("Events").readByQuery({
-    filter: {
+global.meetup = {}
+global.meetup[props.id] = global.meetup[props.id]
+  ? global.meetup[props.id]
+  : await directus.items("Events").readByQuery({
+      filter: {
         id: {
-            _eq: props.id,
+          _eq: props.id,
         },
-    },
-	fields: ["*.*"],
-});
+      },
+      fields: ["*.*"],
+    });
 
-const meetup = getCurrentMeetup.data[0];
-
+console.log(global.meetup[props.id])
+const meetup = global.meetup[props.id].data[0];
 ---
 
 <LayoutSingleMeetup title={meetup.title} description={meetup.description}>
-
-    <MeetupSingle
-        routeId={props.id}
-        getCurrentEvent={meetup}
-    />
-
+  <MeetupSingle routeId={props.id} getCurrentEvent={meetup} />
 </LayoutSingleMeetup>

--- a/src/pages/meetups.astro
+++ b/src/pages/meetups.astro
@@ -5,9 +5,13 @@ import DetailedEventCard from '../components/DetailedEventCard.astro';
 
 
 const directus = await getDirectusClient()
-const response = await directus.items("Events").readByQuery({
-  fields: ["*.*"],
-})
+global.events = global.events
+    ? global.events
+    :  await directus.items("Events").readByQuery({
+	fields: ["*.*"],
+});
+
+let response = global.events
 
 const title = "My event title"
 const description = "my event description"


### PR DESCRIPTION
I noticed the build time was bottlenecked by the api calls to directus

<details>
<summary>BEFORE : builds in 24.28s </summary>

```bash
❯ npm run build

> frontend.mu@0.0.2 build
> astro build

08:40:44 PM [build] output target: static
08:40:44 PM [build] Collecting build info...
08:40:44 PM [build] Completed in 372ms.
08:40:44 PM [build] Building static entrypoints...
08:40:46 PM [build] Completed in 2.38s.

 building client 
Completed in 451ms.


 generating static routes 
▶ src/pages/index.astro
  └─ /index.html (+0.78s)
▶ src/pages/othersponsors.md
  └─ /othersponsors/index.html (+6ms)
▶ src/pages/sponsors.astro
  └─ /sponsors/index.html (+7ms)
▶ src/pages/meetups.astro
  └─ /meetups/index.html (+29ms)
λ src/pages/rss.xml.js
  └─ /rss.xml (+3ms)
▶ src/pages/meetup/[id].astro
  ├─ /meetup/39/index.html (+0.88s)
  ├─ /meetup/38/index.html (+1.86s)
  ├─ /meetup/37/index.html (+2.78s)
  ├─ /meetup/36/index.html (+3.63s)
  ├─ /meetup/17/index.html (+4.47s)
  ├─ /meetup/18/index.html (+5.33s)
  ├─ /meetup/34/index.html (+6.20s)
  ├─ /meetup/35/index.html (+6.99s)
  ├─ /meetup/33/index.html (+7.80s)
  ├─ /meetup/31/index.html (+8.69s)
  ├─ /meetup/32/index.html (+9.51s)
  ├─ /meetup/30/index.html (+10.37s)
  ├─ /meetup/29/index.html (+11.27s)
  ├─ /meetup/28/index.html (+12.14s)
  ├─ /meetup/27/index.html (+13.01s)
  ├─ /meetup/26/index.html (+13.82s)
  ├─ /meetup/25/index.html (+14.73s)
  ├─ /meetup/24/index.html (+15.53s)
  ├─ /meetup/23/index.html (+16.33s)
  ├─ /meetup/22/index.html (+17.67s)
  ├─ /meetup/21/index.html (+18.54s)
  ├─ /meetup/20/index.html (+19.32s)
  └─ /meetup/19/index.html (+20.11s)
▶ src/pages/about.md
  └─ /about/index.html (+2ms)
▶ src/pages/blog/first-post.md
  └─ /blog/first-post/index.html (+2ms)
▶ src/pages/blog.astro
  └─ /blog/index.html (+2ms)
Completed in 21.06s.

@astrojs/sitemap: `sitemap-index.xml` is created.

08:41:08 PM [build] 30 page(s) built in 24.28s
08:41:08 PM [build] Complete!
```
</details>

<details>
<summary>AFTER : builds in 11.34s </summary>

```bash
❯ npm run build

> frontend.mu@0.0.2 build
> astro build

08:47:54 PM [build] output target: static
08:47:54 PM [build] Collecting build info...
08:47:54 PM [build] Completed in 373ms.
08:47:54 PM [build] Building static entrypoints...
08:47:56 PM [build] Completed in 2.29s.

 building client 
Completed in 457ms.


 generating static routes 
▶ src/pages/index.astro
  └─ /index.html (+1.59s)
▶ src/pages/othersponsors.md
  └─ /othersponsors/index.html (+7ms)
▶ src/pages/sponsors.astro
  └─ /sponsors/index.html (+7ms)
▶ src/pages/meetups.astro
  └─ /meetups/index.html (+31ms)
λ src/pages/rss.xml.js
  └─ /rss.xml (+3ms)
▶ src/pages/meetup/[id].astro
  ├─ /meetup/39/index.html (+589ms)
  ├─ /meetup/38/index.html (+0.85s)
  ├─ /meetup/37/index.html (+1.13s)
  ├─ /meetup/36/index.html (+1.40s)
  ├─ /meetup/17/index.html (+1.67s)
  ├─ /meetup/18/index.html (+1.94s)
  ├─ /meetup/34/index.html (+2.20s)
  ├─ /meetup/35/index.html (+2.47s)
  ├─ /meetup/33/index.html (+2.73s)
  ├─ /meetup/31/index.html (+2.99s)
  ├─ /meetup/32/index.html (+3.25s)
  ├─ /meetup/30/index.html (+3.51s)
  ├─ /meetup/29/index.html (+3.78s)
  ├─ /meetup/28/index.html (+4.04s)
  ├─ /meetup/27/index.html (+4.30s)
  ├─ /meetup/26/index.html (+4.56s)
  ├─ /meetup/25/index.html (+4.83s)
  ├─ /meetup/24/index.html (+5.09s)
  ├─ /meetup/23/index.html (+5.36s)
  ├─ /meetup/22/index.html (+5.63s)
  ├─ /meetup/21/index.html (+5.90s)
  ├─ /meetup/20/index.html (+6.17s)
  └─ /meetup/19/index.html (+6.43s)
▶ src/pages/about.md
  └─ /about/index.html (+2ms)
▶ src/pages/blog/first-post.md
  └─ /blog/first-post/index.html (+1ms)
▶ src/pages/blog.astro
  └─ /blog/index.html (+2ms)
Completed in 8.20s.

@astrojs/sitemap: `sitemap-index.xml` is created.

08:48:05 PM [build] 30 page(s) built in 11.34s
08:48:05 PM [build] Complete!

```

</details>

I posted the question to the Astro discord about [caching server side responses](https://discord.com/channels/830184174198718474/1020619913154535525).

They had [a nice little solution](https://discord.com/channels/830184174198718474/830184175176122389/889911170583130132) that basically says: cache the response in a global variable that lives for the duration of the `npm run dev/build` lifespan

```js
export async function getStaticPaths() {
  global.data = global.data
  ? global.data
  : await fetch("https://example.com/json").then((response) => response.json());

// You can also use the ||= or ??= if they are available

  return global.data.map((post) => {
    return {
      params: { slug: post.slug },
      props: { post },
    };
  });
}
```
