### PR TITLE
Implement dynamic og-images using @vercel/og

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -30,7 +30,6 @@ const { title, description, image = '/placeholder-social.png' } = Astro.props;
 <meta property="og:url" content={Astro.url} />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />
-<meta property="og:image" content={new URL(image, Astro.url)} />
 
 <!-- Twitter -->
 <meta property="twitter:card" content="summary_large_image" />

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -11,7 +11,7 @@ export interface Props {
 	image?: string;
 }
 
-const { title, description, image = '/placeholder-social.png' } = Astro.props;
+const { title, description, image = 'https://vercel-og-next.vercel.app/api/fec-home' } = Astro.props;
 ---
 
 <!-- Global Metadata -->
@@ -36,7 +36,6 @@ const { title, description, image = '/placeholder-social.png' } = Astro.props;
 <meta property="twitter:url" content={Astro.url} />
 <meta property="twitter:title" content={title} />
 <meta property="twitter:description" content={description} />
-<meta property="twitter:image" content={new URL(image, Astro.url)} />
 
 <script is:inline>
 	const tod = new Date().getHours();

--- a/src/components/OgImage.astro
+++ b/src/components/OgImage.astro
@@ -19,3 +19,4 @@ if (pageType === "page") {
 ---
 
 <meta property="og:image" content={new URL(imageUrl)} />
+<meta property="twitter:image" content={new URL(imageUrl)} />

--- a/src/components/OgImage.astro
+++ b/src/components/OgImage.astro
@@ -1,0 +1,21 @@
+---
+const { title, pageType, username = "Github" } = Astro.props;
+
+let imageUrl = "";
+if (pageType === "page") {
+  if (typeof title === 'undefined') {
+    imageUrl = "https://vercel-og-next.vercel.app/api/fec-home";
+  } else {
+    imageUrl = "https://vercel-og-next.vercel.app/api/fec-page?title=" + title;
+  }
+} else if (pageType === "speaker") {
+  imageUrl =
+    "https://vercel-og-next.vercel.app/api/fec-speaker?username=" + username;
+} else if (pageType === "event") {
+  imageUrl = "https://vercel-og-next.vercel.app/api/fec-event?title=" + title;
+} else {
+  imageUrl = "https://vercel-og-next.vercel.app/api/fec-home";
+}
+---
+
+<meta property="og:image" content={new URL(imageUrl)} />

--- a/src/layouts/LayoutAbout.astro
+++ b/src/layouts/LayoutAbout.astro
@@ -2,8 +2,8 @@
 import BaseHead from "../components/BaseHead.astro";
 import Header from "../components/NewHeader.astro";
 import Footer from "../components/Footer.astro";
-import Sponsors from "../components/Sponsors.astro";
 import Team from "../components/Team.astro";
+import OgImage from "../components/OgImage.astro";
 
 const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 // const title = 'Front-End Coders Mauritius'
@@ -13,6 +13,8 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 <html lang="en">
   <head>
     <BaseHead title={title} description={description} />
+    <OgImage pageType="page" title="About" />
+
   </head>
 
   <body>

--- a/src/layouts/LayoutCustom.astro
+++ b/src/layouts/LayoutCustom.astro
@@ -3,6 +3,7 @@ import BaseHead from "../components/BaseHead.astro";
 import Header from "../components/NewHeader.astro";
 import Footer from "../components/Footer.astro";
 import Sponsors from "../components/Sponsors.astro";
+import OgImage from "../components/OgImage.astro";
 
 const props = Astro.props
 ---
@@ -10,6 +11,7 @@ const props = Astro.props
 <html lang="en">
 	<head>
 		<BaseHead title={props.title} description={props.description} />
+		<OgImage pageType="page" title={props.title} />
 	</head>
 
 	<body>

--- a/src/layouts/LayoutHome.astro
+++ b/src/layouts/LayoutHome.astro
@@ -3,6 +3,7 @@ import BaseHead from "../components/BaseHead.astro";
 import Header from "../components/NewHeader.astro";
 import Footer from "../components/Footer.astro";
 import Sponsors from "../components/Sponsors.astro";
+import OgImage from "../components/OgImage.astro";
 
 // export interface Props {
 // 	content: {
@@ -14,28 +15,27 @@ import Sponsors from "../components/Sponsors.astro";
 // 	};
 // }
 
-// const {
-// 	content: { title, description, pubDate, updatedDate, heroImage },
-// } = Astro.props;
-const title = 'Front-End Coders Mauritius'
-const description = 'Front-End Coders Mauritius is a community around front-end development based in Mauritius. We also organise monthly meetups free for anyone interested to attend.'
+const {
+  title ,
+  description = "Front-End Coders Mauritius is a community around front-end development based in Mauritius. We also organise monthly meetups free for anyone interested to attend.",
+} = Astro.props;
 ---
 
 <html lang="en">
-	<head>
-		<BaseHead title={title} description={description} />
-	</head>
+  <head>
+    <BaseHead title={title} description={description} />
+    <OgImage pageType="page" title={title} />
+  </head>
 
-	<body>
-		<div>
-			<Header />
+  <body>
+    <div>
+      <Header />
 
-			<slot />
+      <slot />
 
-			<Sponsors />
+      <Sponsors />
 
-
-			<Footer />
-		</div>
-	</body>
+      <Footer />
+    </div>
+  </body>
 </html>

--- a/src/layouts/LayoutSpeaker.astro
+++ b/src/layouts/LayoutSpeaker.astro
@@ -4,9 +4,6 @@ import Header from "../components/NewHeader.astro";
 import Footer from "../components/Footer.astro";
 import OgImage from "../components/OgImage.astro";
 
-const title = 'hi'
-const description = 'hi'
-
 const props = Astro.props
 
 
@@ -15,7 +12,7 @@ const props = Astro.props
 <html lang="en">
 	<head>
 		<BaseHead title={props.title} description={props.description} />
-		<OgImage pageType="event" title={props.title}/>
+		<OgImage pageType="speaker" username={props.username}/>
 	</head>
 
 	<body>

--- a/src/pages/meetups.astro
+++ b/src/pages/meetups.astro
@@ -6,8 +6,8 @@ import { loadEvents } from '../utils/api';
 
 let response = await loadEvents();
 
-const title = "My event title"
-const description = "my event description"
+const title = "All meetups"
+const description = "A list of all meetups we've held"
 
 ---
 
@@ -27,7 +27,6 @@ const description = "my event description"
 	
 			  <div  class="grid-container gap-8">
 				{response.data.map((event) => (
-					// <div>{event.title }</div>
 				  <DetailedEventCard event={event} />
 				))}
 			  </div>	

--- a/src/pages/speaker/[id].astro
+++ b/src/pages/speaker/[id].astro
@@ -1,6 +1,6 @@
 ---
 import SpeakerSingle from "../../components/SpeakerSingle.astro";
-import LayoutSingleMeetup from "../../layouts/LayoutSingleMeetup.astro";
+import LayoutSpeaker from "../../layouts/LayoutSpeaker.astro";
 import { getSpeaker, loadSpeakers } from "../../utils/api";
 
 const props = Astro.params;
@@ -21,7 +21,7 @@ const speaker = await getSpeaker(props.id);
 ---
 
 
-<LayoutSingleMeetup title={speaker.person.name} description="Speaker Profile">
+<LayoutSpeaker title={speaker.person.name} username={speaker.person.github_account} description="Speaker Profile">
     <SpeakerSingle routeId={props.id} speaker={speaker}  />
-</LayoutSingleMeetup>
+</LayoutSpeaker>
 

--- a/src/pages/sponsors.astro
+++ b/src/pages/sponsors.astro
@@ -1,9 +1,11 @@
 ---
 import sponsorTypes from "../data/sponsors.js";
 import Layout from "../layouts/LayoutCustom.astro";
+const title = "Our sponsors"
+const description = ""
 ---
 
-<Layout>
+<Layout  title={title} description={description}>
     <div class="contain">
         <div class="bg-white">
             <div class="lg:py-24">


### PR DESCRIPTION
Recently Vercel announced a cool new package called vercel/og. [Read the announcement here.](https://vercel.com/blog/introducing-vercel-og-image-generation-fast-dynamic-social-card-images)

This solves a long-standing issue of having to manually generate OG Images for static sites. 

I've deployed a sister project where the image generation is handled. 
You can check the implementation here
- https://github.com/Front-End-Coders-Mauritius/vercel-og-next/pull/1

Using this service, which is running on vercel edge, we can now have dynamic og images in frontend.mu

Some examples: 

![image](https://user-images.githubusercontent.com/1721611/195937868-805a6be6-704f-4ed3-a5c6-033d8b11b45a.png)
![image](https://user-images.githubusercontent.com/1721611/195937885-a2b98e6e-4e15-448f-b5fb-6ed0d1f4c4a0.png)
![image](https://user-images.githubusercontent.com/1721611/195937942-eb2db3b0-fd9d-439c-982e-8de6b8a1ffea.png)
![image](https://user-images.githubusercontent.com/1721611/195938056-6773af21-a1a8-458b-8b9a-ed3a11a0cbeb.png)
