### PR TITLE
fix(ui): various ui fixes

### DIFF
--- a/src/components/MeetupSingle.astro
+++ b/src/components/MeetupSingle.astro
@@ -83,7 +83,7 @@ let currentAlbum = fetchAlbumDetails();
                           ? "tagStyle bg-green-100 text-green-800"
                           : "tagStyle bg-yellow-100 text-yellow-800",
                         ,
-                        "p-2 rounded-full text-sm font-medium tracking-wide uppercase",
+                        "p-2 rounded-full text-sm font-medium tracking-wide uppercase px-4",
                       ]}
                     >
                       upcoming

--- a/src/components/Sponsors.astro
+++ b/src/components/Sponsors.astro
@@ -25,8 +25,8 @@ import HeaderLink from "./HeaderLink.astro";
             <p class="text-md md:text-lg text-black font-mono font-bold">
               We're lucky to have sponsors support our community. If you're
               interested in sponsoring us, please reach out to us <a
-                href="mailto:hello@frontend.mu">here</a
-              >
+                href="mailto:hello@frontend.mu" class="underline">here</a
+              >.
             </p>
             <div class="grid place-items-center md:place-items-start">
               <HeaderLink

--- a/src/components/event-card-modern.astro
+++ b/src/components/event-card-modern.astro
@@ -78,12 +78,12 @@ const isUpcoming = () => {
     <div class="flex gap-4 pr-4 border-gray-100">
       {
         event.Venue && (
-          <div class="flex gap-1 md:gap-0 items-center justify-start text-base font-medium leading-3 md:leading-5 text-gray-500">
+          <div class="flex gap-1 md:gap-0 items-center justify-start text-base font-medium text-gray-500">
             <MapPinIcon
               class="mr-1.5 h-[15px] w-[15px] flex-shrink-0 truncate text-gray-500"
               aria-hidden="true"
             />
-            <div class="pt-[2px] line-clamp-1 md:line-clamp-0">
+            <div class="line-clamp-1 md:line-clamp-0">
               {event.Venue}
             </div>
           </div>
@@ -91,7 +91,7 @@ const isUpcoming = () => {
       }
 
       <div
-        class="flex gap-1 md:gap-0 items-center justify-start text-base font-medium leading-3 md:leading-5 text-gray-500"
+        class="flex gap-1 md:gap-0 items-center justify-start text-base font-medium text-gray-500"
       >
         {
           event.Attendees && (
@@ -100,7 +100,7 @@ const isUpcoming = () => {
                 class="mr-1.5 h-[15px] w-[15px] flex-shrink-0 truncate text-gray-500"
                 aria-hidden="true"
               />
-              <div class="pt-[2px] line-clamp-1 md:line-clamp-0">
+              <div class="line-clamp-1 md:line-clamp-0">
                 {event?.Attendees}
               </div>
             </div>

--- a/src/components/event-card-modern.astro
+++ b/src/components/event-card-modern.astro
@@ -52,7 +52,7 @@ const isUpcoming = () => {
               isUpcoming()
                 ? "bg-gray-50 text-gray-700"
                 : "bg-green-50 text-green-600 font-bold",
-              "inline-flex rounded-lg md:p-3 font-mono text-sm font-medium items-center",
+              "inline-flex rounded-lg p-[0.35rem] md:p-3 font-mono text-sm font-medium items-center",
             ]}
           >
             <CalendarIcon class="mr-2 h-6 w-6" />

--- a/src/components/event-card-modern.astro
+++ b/src/components/event-card-modern.astro
@@ -52,7 +52,7 @@ const isUpcoming = () => {
               isUpcoming()
                 ? "bg-gray-50 text-gray-700"
                 : "bg-green-50 text-green-600 font-bold",
-              "inline-flex rounded-xl md:p-3 font-mono text-sm font-medium items-center",
+              "inline-flex rounded-lg md:p-3 font-mono text-sm font-medium items-center",
             ]}
           >
             <CalendarIcon class="mr-2 h-6 w-6" />

--- a/src/components/event-card-modern.astro
+++ b/src/components/event-card-modern.astro
@@ -40,7 +40,7 @@ const isUpcoming = () => {
 
 <div class="py-2 group">
   <div
-    class="relative rounded-xl flex flex-col md:flex-row p-4 md:p-0 gap-2 group bg-brand-0 group-hover:shadow-lg transition-all duration-300 border-2 group-hover:border-brand-400 group-hover:scale-105"
+    class="relative rounded-xl flex flex-col md:flex-row p-4 md:p-0 gap-2 group bg-brand-0 group-hover:shadow-lg transition-all duration-300 border-2 border-brand-100 group-hover:border-brand-400 group-hover:scale-105"
   >
     <!-- Date -->
     {
@@ -64,7 +64,7 @@ const isUpcoming = () => {
 
     <!-- Title -->
     <h3
-      class="leading-2 text-xl font-semibold flex-1 py-2 text-verse-0 group-hover:text-brand-500"
+      class="leading-2 text-xl font-semibold flex-1 py-2 text-verse-0 group-hover:text-brand-500 dark:group-hover:text-brand-100"
     >
       <a
         href={`meetup/${event.id}`}

--- a/src/components/event-card.vue
+++ b/src/components/event-card.vue
@@ -81,22 +81,22 @@ const tiltOptions = {
         </span>
 
         <div
-             class="flex gap-1 md:gap-0 items-center justify-start text-xl font-medium leading-5 text-gray-500">
+             class="flex gap-1 md:gap-0 items-center justify-start text-xl font-medium text-gray-500">
           <UsersIcon
-                     class="mr-1.5 h-[15px] w-[15px] flex-shrink-0 truncate text-gray-500"
+                     class="mr-1.5 h-5 w-5 flex-shrink-0 truncate text-gray-500"
                      aria-hidden="true" />
-          <div v-if="event?.Attendees !== 0" class="pt-[2px] line-clamp-1 md:line-clamp-0">
+          <div v-if="event?.Attendees !== 0" class="line-clamp-1 md:line-clamp-0">
             Attendees {{ event?.Attendees }}
           </div>
-          <div v-else class="pt-[2px]">Seats: {{ event?.Attendees }}</div>
+          <div v-else>Seats: {{ event?.Attendees }}</div>
         </div>
         <div
              v-if="event.Venue"
              class="flex gap-1 md:gap-0 items-center justify-start text-xl font-medium text-gray-500">
           <MapPinIcon
-                              class="ml-[-1px] mr-1.5 h-4 w-4 flex-shrink-0 truncate text-gray-500"
+                              class="ml-[-1px] mr-1.5 h-5 w-5 flex-shrink-0 truncate text-gray-500"
                               aria-hidden="true" />
-          <div class="pt-1 ">{{ event.Venue }}</div>
+          <div>{{ event.Venue }}</div>
         </div>
         <div v-else>No venue added.</div>
       </div>

--- a/src/components/small-event-card.vue
+++ b/src/components/small-event-card.vue
@@ -71,16 +71,16 @@ const isUpcoming = (currentEventDate: string) => {
       </h3>
       <div class="flex gap-4 border-gray-100">
         <div
-          class="flex gap-1 md:gap-0 items-center justify-start text-base font-medium leading-3 md:leading-5 text-gray-500"
+          class="flex gap-1 md:gap-0 items-center justify-start text-base font-medium text-gray-500"
         >
           <UsersIcon
             class="mr-1.5 h-[15px] w-[15px] flex-shrink-0 truncate text-gray-500"
             aria-hidden="true"
           />
-          <div v-if="event?.Attendees !== 0" class="pt-[2px] line-clamp-1 md:line-clamp-0">
+          <div v-if="event?.Attendees !== 0" class="line-clamp-1 md:line-clamp-0">
             Attendees {{ event?.Attendees }}
           </div>
-          <div v-else class="pt-[2px]">Seats: {{ event?.Attendees }}</div>
+          <div v-else>Seats: {{ event?.Attendees }}</div>
         </div>
         <div
           v-if="event.Venue"
@@ -90,7 +90,7 @@ const isUpcoming = (currentEventDate: string) => {
             class="ml-[-1px] mr-1.5 h-4 w-4 flex-shrink-0 truncate text-gray-500"
             aria-hidden="true"
           />
-          <div class="pt-1 line-clamp-1 md:line-clamp-0">{{ event.Venue }}</div>
+          <div class="line-clamp-1 md:line-clamp-0">{{ event.Venue }}</div>
         </div>
         <div v-else>No venue added.</div>
       </div>

--- a/src/pages/sponsors.astro
+++ b/src/pages/sponsors.astro
@@ -19,8 +19,8 @@ const description = "";
             <p class="text-xl text-gray-500">
               We're lucky to have sponsors support our community. If you're
               interested in sponsoring us, please reach out to the organizers <a
-                href="mailto:hello@frontend.mu">here</a
-              >
+                href="mailto:hello@frontend.mu" class="underline">here</a
+              >.
             </p>
           </div>
           <div class="grid gap-20 pt-12 md:grid-cols-2">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-	darkMode: 'class',
+	darkMode: ['class', '[color-scheme="dark"]'],
 	mode: 'jit',
 	content: [
 		'./src/components/**/*.{astro,vue,md,mdx}',


### PR DESCRIPTION
This addresses a few small bugs that I noticed when browsing the site, most of them only noticeable when using dark mode:
1. There's a small gap between the date badge and the card itself that's only noticeable in dark mode
![image](https://user-images.githubusercontent.com/20923978/225940970-878375df-f82c-42b9-981a-02db0cbc6fe2.png)
2. I noticed that the theme toggle uses an attribute on the `body` tag to determine if dark mode is enabled or not and I remembered that that's not the way TailwindCSS detects dark mode by default. A nice side-effect of fixing that was that the navigation bar's colours now change alongside the theme.
3. Using dark mode, cards and buttons throughout the site don't use borders, and the cards in the "Recent Meetups" section use a pretty thick border that's not using the brand colours. I've adjusted that to use a tone of the brand colour (please let me know if that works for you, I can change that to something more suitable/appropriate).
The text also got nearly invisible when hovering over the card there when using dark mode. Changed that to using the brand colour.
Before: 
![image](https://user-images.githubusercontent.com/20923978/225943949-88f564f0-8c8a-4713-ae24-6831d843c17e.png)
![image](https://user-images.githubusercontent.com/20923978/225944058-3cc2554c-b9df-46f1-adb4-4b0614e9ea98.png)
After: 
![image](https://user-images.githubusercontent.com/20923978/225944249-7f297a0d-b005-4bbb-bd6b-86434d273851.png)
![image](https://user-images.githubusercontent.com/20923978/225944285-78919592-5b08-465b-9559-9e5fd92092e6.png)
4. The text for the venue and number of attendees seemed off-center on the y-axis. It seems like that's in some places there was some padding added on top; I believe that there must have been a reason for it but checking on the mobile & tablet & desktop viewport sizes, I can't seem to find anything that breaks when removing it. There was also a fixed line height for the text, resulting in the bottom portion of letters like `g` or `p` to be cut off. Removing that fixed line height fixes this, but also makes the card slightly taller on mobile.
Before: 
![image](https://user-images.githubusercontent.com/20923978/225945881-27ac6e33-8e5f-471b-a747-93a462ae08be.png)
![image](https://user-images.githubusercontent.com/20923978/225945983-d92ab999-c960-4a81-9154-10b2b0a0245e.png)
After:
![image](https://user-images.githubusercontent.com/20923978/225946092-ea0386d6-2fc6-4787-81dd-fb34b276e34a.png)
![image](https://user-images.githubusercontent.com/20923978/225946046-c530b8e0-fc76-464f-8e8c-9bb5daba06f4.png)
5. The text for the "Upcoming" badge seems like a tight fit, adding some extra x-axis padding makes it look more natural.
![image](https://user-images.githubusercontent.com/20923978/225946668-efdb6ced-07bc-485e-8e22-e79104046c19.png)
![image](https://user-images.githubusercontent.com/20923978/225946709-93221ad9-4095-4bda-bae6-b9e376dae6a0.png)
6. In the sponsors section on the home page, added an underline to the link for the email since it wasn't clear if the "View all sponsors" button leads to a way to contact you or if the text itself is a link.
7. For cards in the "Recent Meetups" section, the date badge doesn't have any padding on the mobile viewport size. This looks good on the white theme, but looks off in dark mode. The minimum padding I could add to make it fit the overall apperance of the website website was `.35rem` since adding more padding there makes the card taller overall.
Before: 
![image](https://user-images.githubusercontent.com/20923978/225950516-ed853024-57db-418f-b573-f9765d707ef4.png)
After: 
![image](https://user-images.githubusercontent.com/20923978/225950562-92d7b086-51cd-4cca-8c4c-70d3c768aa75.png)
