### PR TITLE
A simple fix for the overflow problem?

### DIFF
--- a/src/components/HomeHero.astro
+++ b/src/components/HomeHero.astro
@@ -29,7 +29,7 @@ import LogoFec from "../components/LogoFec.astro";
             </div>
           </div>
 
-          <div class="md:w-1/3 grid place-items-center">
+          <div class="grid place-items-center">
             <div class="image-container">
               <div class="image-bg"></div>
 


### PR DESCRIPTION
I had noticed when checking out the website that when the viewport width is between 768px and 1199px, there is an unwanted x-axis scrollbar that appears. 

<img width="178" alt="image" src="https://user-images.githubusercontent.com/23489046/227731924-d1040b81-5adb-4497-a213-913060cefd4d.png">

I had tried different ways to fix it but the simplest and most efficient one was to remove the "md:w-1/3" class from the section containing the logo.

From what I've seen, this change doesn't have any apparent adverse effects on the rest of the website and still maintains the proper flow of responsiveness.