### PR TITLE
Directus Community Cloud to Directus self hosted instance

### DIFF
--- a/src/utils/directus-client.ts
+++ b/src/utils/directus-client.ts
@@ -1,5 +1,5 @@
 import { Directus } from "@directus/sdk";
 export const getDirectusClient = async () => {
-  const directus = new Directus('https://l4yporup.directus.app');
+  const directus = new Directus('https://directus.frontend.mu');
   return directus;
 };


### PR DESCRIPTION
As some of you might be aware, directus (free)community clou has been discontinued, and on April 24th our instance was removed. I contacted the directus team and they were nice enough to provide us with a db dump. FYI, the lowest tier now costs $99/month, which we cannot afford.

I decided to migrate to a digital ocean droplet and self-host directus. Since we only use directus like a backend-as-a-service, and it's only accessed by our CI/CD pipelines, we don't expect much traffic or load on the tiny droplet. 

With the help of @mgules, I've setup another (private) repo where we host the cms files, and it's not operating at a new URL.

This PR should restore all of our CI/CD/Deploy_Preview capabilities that are currently broken due to a dead API endpoint.

We hope to get some server sponsorships in the future, for now, the organizers are sharing the hosting costs