### PR TITLE
Footer Alignment issue on About Page #47

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,7 +4,7 @@ const today = new Date();
 
 <section>
 	<div
-		class="w-full bg-slate-950 dark:bg-black dark:text-white border-gray-100 p-4 text-center text-gray-500 font-light text-xs md:text-normal"
+		class="absolute bottom-0 w-full bg-slate-950 dark:bg-black dark:text-white border-gray-100 p-4 text-center text-gray-500 font-light text-xs md:text-normal"
 	>
 		{today.getFullYear()} - present Front-End Coders Mauritius
 	</div>


### PR DESCRIPTION
Before:
<img width="1385" alt="fullwisth" src="https://github.com/Front-End-Coders-Mauritius/frontendmu-astro/assets/77941119/14ad8597-20a6-4c9f-ac75-a0ef2afe1499">
<img width="1380" alt="mobile" src="https://github.com/Front-End-Coders-Mauritius/frontendmu-astro/assets/77941119/40a5b8a6-6e50-431a-8c22-25ec9b50c69f">


After:
<img width="1383" alt="Screenshot 2023-05-24 at 00 20 31" src="https://github.com/Front-End-Coders-Mauritius/frontendmu-astro/assets/77941119/c70acdbe-b406-4036-ac81-9b1e8e6e166e">
<img width="1385" alt="Screenshot 2023-05-24 at 00 21 33" src="https://github.com/Front-End-Coders-Mauritius/frontendmu-astro/assets/77941119/a3b286db-8cd9-4b95-9112-03c9045ca13d">

Just added a class to stick the footer to the bottom
