### PR TITLE
Single meetup sponsors

### DIFF
--- a/src/components/MeetupSingle.astro
+++ b/src/components/MeetupSingle.astro
@@ -10,6 +10,7 @@ import SessionList from "./SessionList.astro";
 import { ArrowLeftIcon, ArrowRightIcon } from "@heroicons/vue/20/solid";
 import { getPhotos, photoAlbumSource } from "../utils/api";
 import { random } from "../utils/helpers";
+import { Image } from "@astrojs/image/components";
 
 const props = Astro.props;
 
@@ -49,6 +50,11 @@ function fetchAlbumDetails(albumName: string) {
   }
 }
 
+let sponsorTypeMap  = { 
+  'lunch': 'Lunch Sponsor',
+  'venue': 'Venue Sponsor',
+}
+
 let currentAlbum = fetchAlbumDetails(props.getCurrentEvent.album);
 
 const getRelatedPhotoSource = (album: string) => {
@@ -85,25 +91,40 @@ const getRelatedPhotoSource = (album: string) => {
                 {props.getCurrentEvent?.title}
               </h1>
 
-              <!-- {
-                props.getCurrentEvent.description ? (
-                  <div class="mt-6 space-y-6 text-gray-500">
-                    <div
-                      class="text-md prose md:text-lg"
-                      set:html={props.getCurrentEvent.description}
-                    />
-                  </div>
-                ) : (
-                  <div class="text-md prose md:text-lg">
-                    Please add a description.
-                  </div>
-                )
-              } -->
-
               <div class="grid md:grid-cols-2">
                 <SessionList sessions={props.getCurrentEvent.sessions} />
                 <MeetupGallery currentAlbum={currentAlbum} source={photoAlbumSource} animationSpeed={4000} />
               </div>
+
+              <div class="">
+                {props.getCurrentEvent.sponsors && props.getCurrentEvent.sponsors.length > 0 && (
+                  <div class="text-base uppercase text-verse-900 dark:text-slate-200 font-semibold mb-4">Sponsor(s)</div>
+                  <div class="flex flex-col md:flex-row gap-4">
+                    {props.getCurrentEvent.sponsors.map((sponsor) => (
+                      <div class="bg-slate-900/90 p-4 items-center shadow-md rounded-lg flex gap-4">
+                        <Image
+                          class="h-10 w-auto rounded-full object-cover"
+                          src={`https://directus.frontend.mu/assets/` + sponsor.Sponsor_id.Logo.filename_disk}
+                          alt={sponsor.Sponsor_id.Name}
+                          title={sponsor.Sponsor_id.Name}
+                          width={sponsor.Sponsor_id.Logo.width}
+                          height={sponsor.Sponsor_id.Logo.height}
+                        />
+  
+                        <div class="flex text-md font-bold gap-4">
+                          {sponsor.Sponsor_id?.Sponsor_type.map((sponsorType) => (
+                            <div class="flex flex-col items-center bg-yellow-200 border-yellow-500 border-2 p-2 rounded-md text-yellow-800">
+                              <p class="text-center">{sponsorTypeMap[sponsorType]}</p>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    ))}                  
+                  </div>
+                )}
+              </div>
+
+
             </div>
             <!-- Stats section -->
             <div class="mt-10">
@@ -212,46 +233,6 @@ const getRelatedPhotoSource = (album: string) => {
                 }
               </dl>
             </div>
-          </div>
-
-          <div class="flex justify-between gap-10">
-            {
-              props.getCurrentEvent.related.previous && (
-                <a class="ml-4 relative flex flex-col justify-between gap-4 lg:bg-brand-200 overflow-hidden lg:w-full w-1/3 text-black p-4 rounded-md lg:hover:bg-brand-300" href={`/meetup/${props.getCurrentEvent.related.previous.id}`}>
-                  <div class="flex justify-start lg:justify-between items-center relative z-10">
-                    <div>
-                      <strong class="lg:hidden block text-xl gap-2">Previous Meetup</strong>
-                      <ArrowLeftIcon class="h-6 w-6" />
-                    </div>
-
-                    <div class="text-right hidden lg:block">
-                      <strong class="text-2xl">Previous meetup</strong>
-                      <p class="lg:text-2xl pt-4">{props.getCurrentEvent.related.previous.title}</p>
-                      <p class="lg:text-xl">{props.getCurrentEvent.related.previous.Venue}</p>
-                      <p>{props.getCurrentEvent.related.previous.Date}</p>
-                    </div>
-                  </div>
-                </a>
-              )
-            }
-            {
-              props.getCurrentEvent.related.next && (
-                <a class="mr-4 relative flex flex-col justify-between gap-4 lg:bg-brand-200 overflow-hidden text-black p-4 lg:w-full w-1/3 rounded-md lg:hover:bg-brand-300" href={`/meetup/${props.getCurrentEvent.related.next.id}`}>
-                  <div class="flex justify-end lg:justify-between items-center relative z-10">
-                    <div class="text-left lg:block hidden">
-                      <strong class="text-2xl">Next Meetup</strong>
-                      <p class="lg:text-2xl pt-4">{props.getCurrentEvent.related.next.title}</p>
-                      <p class="lg:text-xl">{props.getCurrentEvent.related.next.Venue}</p>
-                      <p>{props.getCurrentEvent.related.next.Date}</p>
-                    </div>
-                    <div class="flex flex-col items-end gap-2">
-                      <strong class="lg:hidden block text-xl text-right">Next Meetup</strong>
-                      <ArrowRightIcon class="h-6 w-6" />
-                    </div>
-                  </div>
-                </a>
-              )
-            }
           </div>
         </div>
 

--- a/src/components/MeetupSingle.astro
+++ b/src/components/MeetupSingle.astro
@@ -10,7 +10,7 @@ import SessionList from "./SessionList.astro";
 import { ArrowLeftIcon, ArrowRightIcon } from "@heroicons/vue/20/solid";
 import { getPhotos, photoAlbumSource } from "../utils/api";
 import { random } from "../utils/helpers";
-import { Image } from "@astrojs/image/components";
+import MeetupSonspor from "./MeetupSonspor.astro";
 
 const props = Astro.props;
 
@@ -51,10 +51,7 @@ function fetchAlbumDetails(albumName: string) {
   }
 }
 
-let sponsorTypeMap = {
-  lunch: "Lunch Sponsor",
-  venue: "Venue Sponsor",
-};
+
 
 let currentAlbum = fetchAlbumDetails(props.getCurrentEvent.album);
 
@@ -125,54 +122,8 @@ const getRelatedPhotoSource = (album: string) => {
                 />
               </div>
 
-              <div class="">
-                {
-                  props.getCurrentEvent.sponsors &&
-                    props.getCurrentEvent.sponsors.length > 0 && (
-                      <>
-                        <div class="text-base uppercase text-verse-900 dark:text-slate-200 font-semibold mb-4">
-                          Sponsor(s)
-                        </div>
-                        <div class="flex flex-col md:flex-row gap-4">
-                          {props.getCurrentEvent.sponsors.map((sponsor) => (
-                            <div
-                              class:list={[
-                                sponsor.Sponsor_id.darkbg
-                                  ? "bg-slate-900/90"
-                                  : "bg-white",
-                                "p-4 items-center shadow-md rounded-lg flex gap-4",
-                              ]}
-                            >
-                              <Image
-                                class="h-10 w-auto object-cover"
-                                src={
-                                  `https://directus.frontend.mu/assets/` +
-                                  sponsor.Sponsor_id.Logo.filename_disk
-                                }
-                                alt={sponsor.Sponsor_id.Name}
-                                title={sponsor.Sponsor_id.Name}
-                                width={sponsor.Sponsor_id.Logo.width}
-                                height={sponsor.Sponsor_id.Logo.height}
-                              />
-
-                              <div class="flex text-md font-bold gap-4">
-                                {sponsor.Sponsor_id?.Sponsor_type.map(
-                                  (sponsorType) => (
-                                    <div class="flex flex-col items-center bg-yellow-200 border-yellow-500 border-2 p-2 rounded-md text-yellow-800">
-                                      <p class="text-center">
-                                        {sponsorTypeMap[sponsorType]}
-                                      </p>
-                                    </div>
-                                  )
-                                )}
-                              </div>
-                            </div>
-                          ))}
-                        </div>
-                      </>
-                    )
-                }
-              </div>
+              <MeetupSonspor sponsors={props.getCurrentEvent.sponsors} />
+             
             </div>
             <!-- Stats section -->
             <div class="mt-10">

--- a/src/components/MeetupSingle.astro
+++ b/src/components/MeetupSingle.astro
@@ -15,7 +15,8 @@ import { Image } from "@astrojs/image/components";
 const props = Astro.props;
 
 const dateInPast = function (firstDate: Date, secondDate: Date) {
-  if (firstDate.setHours(0, 0, 0, 0) <= secondDate.setHours(0, 0, 0, 0)) return true;
+  if (firstDate.setHours(0, 0, 0, 0) <= secondDate.setHours(0, 0, 0, 0))
+    return true;
 
   return false;
 };
@@ -50,10 +51,10 @@ function fetchAlbumDetails(albumName: string) {
   }
 }
 
-let sponsorTypeMap  = { 
-  'lunch': 'Lunch Sponsor',
-  'venue': 'Venue Sponsor',
-}
+let sponsorTypeMap = {
+  lunch: "Lunch Sponsor",
+  venue: "Venue Sponsor",
+};
 
 let currentAlbum = fetchAlbumDetails(props.getCurrentEvent.album);
 
@@ -70,78 +71,133 @@ const getRelatedPhotoSource = (album: string) => {
       <div class="pb-10 md:pb-24">
         <div class="contain">
           <div class="relative">
-            <div aria-hidden="true" class="hidden sm:block lg:inset-y-0 lg:right-0 lg:w-screen">
-              <div class="inset-y-0 right-1/2 w-full rounded-r-3xl bg-gray-50 lg:right-72"></div>
+            <div
+              aria-hidden="true"
+              class="hidden sm:block lg:inset-y-0 lg:right-0 lg:w-screen"
+            >
+              <div
+                class="inset-y-0 right-1/2 w-full rounded-r-3xl bg-gray-50 lg:right-72"
+              >
+              </div>
               <IconDots class="w-[600px] opacity-5 saturate-0" />
             </div>
           </div>
 
-          <div class="relative mx-auto px-8 py-3 sm:px-6 md:px-0 md:mx-0 md:py-24">
+          <div
+            class="relative mx-auto px-8 py-3 sm:px-6 md:px-0 md:mx-0 md:py-24"
+          >
             <!-- Content area -->
             <div>
               {
                 isUpcoming() && (
                   <div class="flex w-full items-center justify-start pb-4">
-                    <p class:list={[isUpcoming() ? "tagStyle bg-green-100 text-green-800" : "tagStyle bg-yellow-100 text-yellow-800", , "p-2 rounded-full text-sm font-medium tracking-wide uppercase px-4"]}>upcoming</p>
+                    <p
+                      class:list={[
+                        isUpcoming()
+                          ? "tagStyle bg-green-100 text-green-800"
+                          : "tagStyle bg-yellow-100 text-yellow-800",
+                        ,
+                        "p-2 rounded-full text-sm font-medium tracking-wide uppercase px-4",
+                      ]}
+                    >
+                      upcoming
+                    </p>
                   </div>
                 )
               }
-              <div class="text-base uppercase text-verse-900 dark:text-slate-200 font-semibold">Topic</div>
-              <h1 class="text-3xl font-extrabold tracking-loose text-verse-500 md:text-4xl lg:text-6xl">
+              <div
+                class="text-base uppercase text-verse-900 dark:text-slate-200 font-semibold"
+              >
+                Topic
+              </div>
+              <h1
+                class="text-3xl font-extrabold tracking-loose text-verse-500 md:text-4xl lg:text-6xl"
+              >
                 {props.getCurrentEvent?.title}
               </h1>
 
               <div class="grid md:grid-cols-2">
                 <SessionList sessions={props.getCurrentEvent.sessions} />
-                <MeetupGallery currentAlbum={currentAlbum} source={photoAlbumSource} animationSpeed={4000} />
+                <MeetupGallery
+                  currentAlbum={currentAlbum}
+                  source={photoAlbumSource}
+                  animationSpeed={4000}
+                />
               </div>
 
               <div class="">
-                {props.getCurrentEvent.sponsors && props.getCurrentEvent.sponsors.length > 0 && (
-                  <div class="text-base uppercase text-verse-900 dark:text-slate-200 font-semibold mb-4">Sponsor(s)</div>
-                  <div class="flex flex-col md:flex-row gap-4">
-                    {props.getCurrentEvent.sponsors.map((sponsor) => (
-                      <div class="bg-slate-900/90 p-4 items-center shadow-md rounded-lg flex gap-4">
-                        <Image
-                          class="h-10 w-auto rounded-full object-cover"
-                          src={`https://directus.frontend.mu/assets/` + sponsor.Sponsor_id.Logo.filename_disk}
-                          alt={sponsor.Sponsor_id.Name}
-                          title={sponsor.Sponsor_id.Name}
-                          width={sponsor.Sponsor_id.Logo.width}
-                          height={sponsor.Sponsor_id.Logo.height}
-                        />
-  
-                        <div class="flex text-md font-bold gap-4">
-                          {sponsor.Sponsor_id?.Sponsor_type.map((sponsorType) => (
-                            <div class="flex flex-col items-center bg-yellow-200 border-yellow-500 border-2 p-2 rounded-md text-yellow-800">
-                              <p class="text-center">{sponsorTypeMap[sponsorType]}</p>
+                {
+                  props.getCurrentEvent.sponsors &&
+                    props.getCurrentEvent.sponsors.length > 0 && (
+                      <>
+                        <div class="text-base uppercase text-verse-900 dark:text-slate-200 font-semibold mb-4">
+                          Sponsor(s)
+                        </div>
+                        <div class="flex flex-col md:flex-row gap-4">
+                          {props.getCurrentEvent.sponsors.map((sponsor) => (
+                            <div
+                              class:list={[
+                                sponsor.Sponsor_id.darkbg
+                                  ? "bg-slate-900/90"
+                                  : "bg-gray-100",
+                                "p-4 items-center shadow-md rounded-lg flex gap-4",
+                              ]}
+                            >
+                              <Image
+                                class="h-10 w-auto rounded-full object-cover"
+                                src={
+                                  `https://directus.frontend.mu/assets/` +
+                                  sponsor.Sponsor_id.Logo.filename_disk
+                                }
+                                alt={sponsor.Sponsor_id.Name}
+                                title={sponsor.Sponsor_id.Name}
+                                width={sponsor.Sponsor_id.Logo.width}
+                                height={sponsor.Sponsor_id.Logo.height}
+                              />
+
+                              <div class="flex text-md font-bold gap-4">
+                                {sponsor.Sponsor_id?.Sponsor_type.map(
+                                  (sponsorType) => (
+                                    <div class="flex flex-col items-center bg-yellow-200 border-yellow-500 border-2 p-2 rounded-md text-yellow-800">
+                                      <p class="text-center">
+                                        {sponsorTypeMap[sponsorType]}
+                                      </p>
+                                    </div>
+                                  )
+                                )}
+                              </div>
                             </div>
                           ))}
                         </div>
-                      </div>
-                    ))}                  
-                  </div>
-                )}
+                      </>
+                    )
+                }
               </div>
-
-
             </div>
             <!-- Stats section -->
             <div class="mt-10">
-              <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-4 md:gap-y-8">
+              <dl
+                class="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-4 md:gap-y-8"
+              >
                 {
                   props.getCurrentEvent.Date && (
                     <div class="border-t-2 border-brand-100 pt-6">
                       <dt class="text-base font-medium text-verse-500">Date</dt>
-                      <dd class="text-2xl font-extrabold tracking-tight text-verse-900 dark:text-slate-200 md:text-3xl">{new Date(props.getCurrentEvent.Date).toDateString()}</dd>
+                      <dd class="text-2xl font-extrabold tracking-tight text-verse-900 dark:text-slate-200 md:text-3xl">
+                        {new Date(props.getCurrentEvent.Date).toDateString()}
+                      </dd>
                     </div>
                   )
                 }
                 {
                   props.getCurrentEvent.Venue && (
                     <div class="border-t-2 border-brand-100 pt-4 md:pt-6">
-                      <dt class="text-base font-medium text-verse-500">Venue</dt>
-                      <dd class="text-2xl font-extrabold tracking-tight text-verse-900 dark:text-slate-200 md:text-3xl">{props.getCurrentEvent.Venue}</dd>
+                      <dt class="text-base font-medium text-verse-500">
+                        Venue
+                      </dt>
+                      <dd class="text-2xl font-extrabold tracking-tight text-verse-900 dark:text-slate-200 md:text-3xl">
+                        {props.getCurrentEvent.Venue}
+                      </dd>
                     </div>
                   )
                 }
@@ -149,23 +205,33 @@ const getRelatedPhotoSource = (album: string) => {
                   props.getCurrentEvent.Time && (
                     <div class="border-t-2 border-brand-100 pt-4 md:pt-6">
                       <dt class="text-base font-medium text-verse-500">Time</dt>
-                      <dd class="text-2xl font-extrabold tracking-tight text-verse-900 dark:text-slate-200 md:text-3xl">{props.getCurrentEvent.Time}</dd>
+                      <dd class="text-2xl font-extrabold tracking-tight text-verse-900 dark:text-slate-200 md:text-3xl">
+                        {props.getCurrentEvent.Time}
+                      </dd>
                     </div>
                   )
                 }
                 {
                   props.getCurrentEvent.Location && (
                     <div class="border-t-2 border-brand-100 pt-4 md:pt-6">
-                      <dt class="text-base font-medium text-verse-500">Location</dt>
-                      <dd class="text-2xl font-extrabold tracking-tight text-verse-900 dark:text-slate-200 md:text-3xl">{props.getCurrentEvent.Location}</dd>
+                      <dt class="text-base font-medium text-verse-500">
+                        Location
+                      </dt>
+                      <dd class="text-2xl font-extrabold tracking-tight text-verse-900 dark:text-slate-200 md:text-3xl">
+                        {props.getCurrentEvent.Location}
+                      </dd>
                     </div>
                   )
                 }
                 {
                   props.getCurrentEvent.Attendees && (
                     <div v-if="" class="border-t-2 border-brand-100 pt-6">
-                      <dt class="text-base font-medium text-verse-500">Seats Limit</dt>
-                      <dd class="text-2xl font-extrabold tracking-tight text-verse-900 dark:text-slate-200 md:text-3xl">{props.getCurrentEvent.Attendees}</dd>
+                      <dt class="text-base font-medium text-verse-500">
+                        Seats Limit
+                      </dt>
+                      <dd class="text-2xl font-extrabold tracking-tight text-verse-900 dark:text-slate-200 md:text-3xl">
+                        {props.getCurrentEvent.Attendees}
+                      </dd>
                     </div>
                   )
                 }
@@ -181,19 +247,29 @@ const getRelatedPhotoSource = (album: string) => {
                   }
 
                   function shareOnFacebook() {
-                    const navUrl = "https://www.facebook.com/sharer/sharer.php?u=" + `${window.location.href}`;
+                    const navUrl =
+                      "https://www.facebook.com/sharer/sharer.php?u=" +
+                      `${window.location.href}`;
                     window.open(navUrl, "_blank");
                   }
 
                   function shareOnTwitter() {
-                    const getTitleFromDataTitle = document.querySelector("[data-title]").getAttribute("data-title");
-                    const str = encodeURIComponent(" #mauritius #frontendcoders ");
-                    const navUrl = `https://twitter.com/intent/tweet?text=${getTitleFromDataTitle}${str}` + `${window.location.href}`;
+                    const getTitleFromDataTitle = document
+                      .querySelector("[data-title]")
+                      .getAttribute("data-title");
+                    const str = encodeURIComponent(
+                      " #mauritius #frontendcoders "
+                    );
+                    const navUrl =
+                      `https://twitter.com/intent/tweet?text=${getTitleFromDataTitle}${str}` +
+                      `${window.location.href}`;
                     window.open(navUrl, "_blank");
                   }
 
                   function shareOnLinkedIn() {
-                    const navUrl = "http://www.linkedin.com/shareArticle?mini=true&url=" + `${window.location.href}`;
+                    const navUrl =
+                      "http://www.linkedin.com/shareArticle?mini=true&url=" +
+                      `${window.location.href}`;
                     window.open(navUrl, "_blank");
                   }
                 </script>
@@ -202,22 +278,47 @@ const getRelatedPhotoSource = (album: string) => {
                 <div class="border-y-2 border-brand-100 pt-4 md:pt-6">
                   <dt class="text-base font-medium text-verse-500">Share</dt>
                   <div class="flex gap-8 py-4">
-                    <button class="hover:text-[#4267B2] text-verse-0" onclick="shareOnFacebook()">
+                    <button
+                      class="hover:text-[#4267B2] text-verse-0"
+                      onclick="shareOnFacebook()"
+                    >
                       <IconFacebook class="w-10 md:w-12" />
                     </button>
-                    <button class="hover:text-[#00acee] text-verse-0" onclick="shareOnTwitter()">
+                    <button
+                      class="hover:text-[#00acee] text-verse-0"
+                      onclick="shareOnTwitter()"
+                    >
                       <IconTwitter class="w-10 md:w-12" />
                     </button>
-                    <button class="hover:text-[#007db1] text-verse-0" onclick="shareOnLinkedIn()">
+                    <button
+                      class="hover:text-[#007db1] text-verse-0"
+                      onclick="shareOnLinkedIn()"
+                    >
                       <IconLinkedin class="w-10 md:w-12" />
                     </button>
                   </div>
-                  <dd class="flex justify-between rounded-md bg-gray-100 mt-2 px-2 py-1 lg:w-[450px]">
-                    <input id="myInput" class="text-md break-words bg-gray-100pr-2 tracking-tight bg-gray-100 text-gray-600 line-clamp-3 w-[500px]" type="text" value={`https://frontend.mu/meetup/${props.routeId}/`} onclick="copy()" />
+                  <dd
+                    class="flex justify-between rounded-md bg-gray-100 mt-2 px-2 py-1 lg:w-[450px]"
+                  >
+                    <input
+                      id="myInput"
+                      class="text-md break-words bg-gray-100pr-2 tracking-tight bg-gray-100 text-gray-600 line-clamp-3 w-[500px]"
+                      type="text"
+                      value={`https://frontend.mu/meetup/${props.routeId}/`}
+                      onclick="copy()"
+                    />
                     <div class="cursor-pointer" onclick="copy()">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                        <path d="M8 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z"></path>
-                        <path d="M6 3a2 2 0 00-2 2v11a2 2 0 002 2h8a2 2 0 002-2V5a2 2 0 00-2-2 3 3 0 01-3 3H9a3 3 0 01-3-3z"></path>
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        class="h-5 w-5"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                      >
+                        <path d="M8 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z"
+                        ></path>
+                        <path
+                          d="M6 3a2 2 0 00-2 2v11a2 2 0 002 2h8a2 2 0 002-2V5a2 2 0 00-2-2 3 3 0 01-3 3H9a3 3 0 01-3-3z"
+                        ></path>
                       </svg>
                     </div>
                   </dd>
@@ -227,7 +328,13 @@ const getRelatedPhotoSource = (album: string) => {
                 {
                   isUpcoming() && (
                     <div class="md:border-t-2 border-brand-100 pt-4 md:pt-8 flex flex-col justify-center items-center md:items-start gap-4">
-                      <dd class="text-2xl font-extrabold tracking-tight text-verse-900 dark:text-slate-200 md:text-3xl">{props.getCurrentEvent.rsvplink && <FecAnchor href={props.getCurrentEvent.rsvplink}>Book my seat</FecAnchor>}</dd>
+                      <dd class="text-2xl font-extrabold tracking-tight text-verse-900 dark:text-slate-200 md:text-3xl">
+                        {props.getCurrentEvent.rsvplink && (
+                          <FecAnchor href={props.getCurrentEvent.rsvplink}>
+                            Book my seat
+                          </FecAnchor>
+                        )}
+                      </dd>
                     </div>
                   )
                 }

--- a/src/components/MeetupSingle.astro
+++ b/src/components/MeetupSingle.astro
@@ -155,10 +155,10 @@ const getRelatedPhotoSource = (album: string) => {
                                 height={sponsor.Sponsor_id.Logo.height}
                               />
 
-                              <div class="flex text-sm font-bold gap-4">
+                              <div class="flex text-md font-bold gap-4">
                                 {sponsor.Sponsor_id?.Sponsor_type.map(
                                   (sponsorType) => (
-                                    <div class="flex flex-col items-center  p-2 rounded-md text-yellow-800">
+                                    <div class="flex flex-col items-center bg-yellow-200 border-yellow-500 border-2 p-2 rounded-md text-yellow-800">
                                       <p class="text-center">
                                         {sponsorTypeMap[sponsorType]}
                                       </p>

--- a/src/components/MeetupSingle.astro
+++ b/src/components/MeetupSingle.astro
@@ -139,12 +139,12 @@ const getRelatedPhotoSource = (album: string) => {
                               class:list={[
                                 sponsor.Sponsor_id.darkbg
                                   ? "bg-slate-900/90"
-                                  : "bg-gray-100",
+                                  : "bg-white",
                                 "p-4 items-center shadow-md rounded-lg flex gap-4",
                               ]}
                             >
                               <Image
-                                class="h-10 w-auto rounded-full object-cover"
+                                class="h-10 w-auto object-cover"
                                 src={
                                   `https://directus.frontend.mu/assets/` +
                                   sponsor.Sponsor_id.Logo.filename_disk
@@ -155,10 +155,10 @@ const getRelatedPhotoSource = (album: string) => {
                                 height={sponsor.Sponsor_id.Logo.height}
                               />
 
-                              <div class="flex text-md font-bold gap-4">
+                              <div class="flex text-sm font-bold gap-4">
                                 {sponsor.Sponsor_id?.Sponsor_type.map(
                                   (sponsorType) => (
-                                    <div class="flex flex-col items-center bg-yellow-200 border-yellow-500 border-2 p-2 rounded-md text-yellow-800">
+                                    <div class="flex flex-col items-center  p-2 rounded-md text-yellow-800">
                                       <p class="text-center">
                                         {sponsorTypeMap[sponsorType]}
                                       </p>

--- a/src/components/MeetupSonspor.astro
+++ b/src/components/MeetupSonspor.astro
@@ -21,9 +21,9 @@ let sponsorTypeMap = {
                         <div
                             class:list={[
                                 sponsor.Sponsor_id.darkbg
-                                    ? "bg-slate-900/90"
-                                    : "bg-white",
-                                "p-4 items-center shadow-md rounded-lg flex gap-4",
+                                    ? "bg-slate-900/90 text-slate-100"
+                                    : "bg-white text-slate-800",
+                                "p-4 items-center shadow-md rounded-lg flex gap-4 text-xs",
                             ]}
                         >
                             <Image
@@ -41,8 +41,8 @@ let sponsorTypeMap = {
                             <div class="flex text-md font-bold gap-4">
                                 {sponsor.Sponsor_id?.Sponsor_type.map(
                                     (sponsorType) => (
-                                        <div class="flex flex-col items-center bg-yellow-200 border-yellow-500 border-2 p-2 rounded-md text-yellow-800">
-                                            <p class="text-center">
+                                        <div class="flex flex-col items-center bg-gray-200/10 border-gray-500/10 border-2 p-2 rounded-md">
+                                            <p class="text-left uppercase font-black opacity-70 cursor-help" title={`${sponsor.Sponsor_id.Name} sponsored the ${sponsorType} for this meetup`}>
                                                 {sponsorTypeMap[sponsorType]}
                                             </p>
                                         </div>

--- a/src/components/MeetupSonspor.astro
+++ b/src/components/MeetupSonspor.astro
@@ -1,0 +1,58 @@
+---
+import { Image } from "@astrojs/image/components";
+
+const props = Astro.props;
+
+let sponsorTypeMap = {
+    lunch: "Lunch Sponsor",
+    venue: "Venue Sponsor",
+};
+---
+
+<div class="">
+    {
+        props.sponsors && props.sponsors.length > 0 && (
+            <>
+                <div class="text-base uppercase text-verse-900 dark:text-slate-200 font-semibold mb-4">
+                    Sponsor(s)
+                </div>
+                <div class="flex flex-col md:flex-row gap-4">
+                    {props.sponsors.map((sponsor) => (
+                        <div
+                            class:list={[
+                                sponsor.Sponsor_id.darkbg
+                                    ? "bg-slate-900/90"
+                                    : "bg-white",
+                                "p-4 items-center shadow-md rounded-lg flex gap-4",
+                            ]}
+                        >
+                            <Image
+                                class="h-10 w-auto object-cover"
+                                src={
+                                    `https://directus.frontend.mu/assets/` +
+                                    sponsor.Sponsor_id.Logo.filename_disk
+                                }
+                                alt={sponsor.Sponsor_id.Name}
+                                title={sponsor.Sponsor_id.Name}
+                                width={sponsor.Sponsor_id.Logo.width}
+                                height={sponsor.Sponsor_id.Logo.height}
+                            />
+
+                            <div class="flex text-md font-bold gap-4">
+                                {sponsor.Sponsor_id?.Sponsor_type.map(
+                                    (sponsorType) => (
+                                        <div class="flex flex-col items-center bg-yellow-200 border-yellow-500 border-2 p-2 rounded-md text-yellow-800">
+                                            <p class="text-center">
+                                                {sponsorTypeMap[sponsorType]}
+                                            </p>
+                                        </div>
+                                    )
+                                )}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </>
+        )
+    }
+</div>

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -7,7 +7,7 @@ const directus = await getDirectusClient();
 // Events
 async function loadEventsUncached() {
   const events = await directus.items("Events").readByQuery({
-    fields: ["*.*", "sessions.Events_id.*", "sessions.Session_id.speakers.name", "sessions.Session_id.title", "sessions.Session_id.speakers.id", "sessions.Session_id.speakers.github_account"],
+    fields: ["*.*", "sessions.Events_id.*", "sessions.Session_id.speakers.name", "sessions.Session_id.title", "sessions.Session_id.speakers.id", "sessions.Session_id.speakers.github_account", "sponsors.Sponsor_id.*.*"],
   });
 
   return events;
@@ -38,6 +38,7 @@ export const getRelatedEvent = (events, eventId) => {
 export async function getEvent(id: string | number) {
   const events = await loadEvents();
   let event = events.data.find((ev) => ev.id == id);
+
   event.related = getRelatedEvent(events, id);
 
   if (event === null) {


### PR DESCRIPTION
This PR introduces a Sponsor segment for each meetup. The sponsors are specified in the CMS.
There are two types of sponsors for now, `Venue` and `Lunch`. 
Sponsors have: 
- Name
- Logo
- Link
- Type
- hasDarkBg (for better visuals when sponsor need white vs black bg)

It's possible to have multiple sponsors per meetup

Screenshot: 
**Light mode**
![image](https://github.com/Front-End-Coders-Mauritius/frontendmu-astro/assets/1721611/3681ce54-2ee8-49f7-866f-40d14618d168)

**Dark mode**
![image](https://github.com/Front-End-Coders-Mauritius/frontendmu-astro/assets/1721611/0f8e35be-6f87-44b7-9393-5a88cdf76fd8)
