### PR TITLE
[Feat] Endpoints - Entry, Team, Meetup

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,9 +6,24 @@ import Icons from 'unplugin-icons/vite'
 
 import vue from "@astrojs/vue";
 
+const SERVER_PORT = 3000;
+const LOCALHOST_URL = `http://localhost:${SERVER_PORT}`;
+
+const LIVE_URL = "https://frontend.mu";
+
+// checks if app is served using astro build script
+const SCRIPT = process.env.npm_lifecycle_script || "";
+const isBuild = SCRIPT.includes("astro build");
+
+let BASE_URL = LOCALHOST_URL;
+
+if (isBuild) {
+  BASE_URL = LIVE_URL;
+}
+
 // https://astro.build/config
 export default defineConfig({
-  site: "https://frontend.mu",
+  site: BASE_URL,
   integrations: [
     mdx(),
     sitemap(),

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,24 +6,9 @@ import Icons from 'unplugin-icons/vite'
 
 import vue from "@astrojs/vue";
 
-const SERVER_PORT = 3000;
-const LOCALHOST_URL = `http://localhost:${SERVER_PORT}`;
-
-const LIVE_URL = "https://frontend.mu";
-
-// checks if app is served using astro build script
-const SCRIPT = process.env.npm_lifecycle_script || "";
-const isBuild = SCRIPT.includes("astro build");
-
-let BASE_URL = LOCALHOST_URL;
-
-if (isBuild) {
-  BASE_URL = LIVE_URL;
-}
-
 // https://astro.build/config
 export default defineConfig({
-  site: BASE_URL,
+  site: "https://frontend.mu",
   integrations: [
     mdx(),
     sitemap(),

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,6 +6,13 @@ const today = new Date();
   <div
     class="absolute bottom-0 w-full bg-verse-950 dark:bg-black dark:text-white border-gray-100 p-4 text-center text-gray-500 font-light text-xs md:text-normal"
   >
-    2016 - {today.getFullYear()} ~ Front-End Coders Mauritius
+    2016 - {today.getFullYear()} ~ Front-End Coders Mauritius |
+    <a
+      href="/api/entry.json"
+      target="_blank"
+      class="underline"
+    >
+      API
+    </a>
   </div>
 </section>

--- a/src/components/Team.astro
+++ b/src/components/Team.astro
@@ -6,7 +6,7 @@ import { vTransitionName } from "@utils/helpers";
 import BaseHeading from "./base/BaseHeading.astro";
 import Contributors from "./../data/contributors.json";
 
-const people = [
+export const people = [
   {
     name: "Sandeep Ramgolam",
     role: "Lead Organiser",

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,5 +4,3 @@
 export const SITE_TITLE = 'Front-End Coders Mauritius';
 export const SITE_DESCRIPTION = 'Community of Front-End developers who share their passions for the web. Events, workshops and conferences occurs regularly.';
 
-const BASE_URL = new URL(import.meta.env.SITE);
-export const SITE_URL = BASE_URL.origin;

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,3 +3,6 @@
 
 export const SITE_TITLE = 'Front-End Coders Mauritius';
 export const SITE_DESCRIPTION = 'Community of Front-End developers who share their passions for the web. Events, workshops and conferences occurs regularly.';
+
+const BASE_URL = new URL(import.meta.env.SITE);
+export const SITE_URL = BASE_URL.origin;

--- a/src/pages/api/entry.json.ts
+++ b/src/pages/api/entry.json.ts
@@ -1,0 +1,17 @@
+import type { APIRoute } from 'astro';
+
+const BASE_URL = new URL(import.meta.env.SITE);
+const SITE_URL = BASE_URL.origin;
+
+// list of all available api routes
+// SITEURL/api/entry.json
+export const get: APIRoute = async () => {
+  return ({
+    body: JSON.stringify({
+      api_routes: {
+        team: `${SITE_URL}/api/team.json`,
+        meetups: `${SITE_URL}/api/meetups.json`
+      }
+    })
+  });
+}

--- a/src/pages/api/entry.json.ts
+++ b/src/pages/api/entry.json.ts
@@ -1,7 +1,6 @@
 import type { APIRoute } from 'astro';
 
-const BASE_URL = new URL(import.meta.env.SITE);
-const SITE_URL = BASE_URL.origin;
+import { SITE_URL } from "../../config";
 
 // list of all available api routes
 // SITEURL/api/entry.json

--- a/src/pages/api/entry.json.ts
+++ b/src/pages/api/entry.json.ts
@@ -1,10 +1,9 @@
 import type { APIRoute } from 'astro';
 
-import { SITE_URL } from "../../config";
-
 // list of all available api routes
 // SITEURL/api/entry.json
-export const get: APIRoute = async () => {
+export const get: APIRoute = async ({ request}) => {
+  const SITE_URL = new URL(request.url).origin;
   return ({
     body: JSON.stringify({
       api_routes: {

--- a/src/pages/api/meetups.json.ts
+++ b/src/pages/api/meetups.json.ts
@@ -1,7 +1,6 @@
 import type { APIRoute } from 'astro';
 import { loadEvents } from "@utils/api";
 
-import { SITE_URL } from "../../config";
 import { Meetup } from "../../components/HomeLatestMeetup.astro";
 
 // matches api response as on 13 aug 2023
@@ -47,7 +46,7 @@ const getSessionsDetails = (sessions: Data["sessions"]) => {
   })) || [];
 }
 
-const meetups = response.data.reduce((acc, event) => {
+const meetups = (SITE_URL: string) => response.data.reduce((acc, event) => {
   const year = new Date(event.Date).getFullYear();
 
   if (!acc[year]) {
@@ -83,10 +82,11 @@ const meetups = response.data.reduce((acc, event) => {
 // topics -> [] of { title, speaker, github_account }
 // sponsors -> [] of { name, url }
 // live_url
-export const get: APIRoute = async () => {
+export const get: APIRoute = async ({ request }) => {
+  const SITE_URL = new URL(request.url).origin;
   return ({
     body: JSON.stringify({
-      ...meetups
+      ...meetups(SITE_URL)
     })
   });
 }

--- a/src/pages/api/meetups.json.ts
+++ b/src/pages/api/meetups.json.ts
@@ -1,0 +1,92 @@
+import type { APIRoute } from 'astro';
+import { loadEvents } from "@utils/api";
+
+import { SITE_URL } from "../../config";
+import { Meetup } from "../../components/HomeLatestMeetup.astro";
+
+// matches api response as on 13 aug 2023
+interface Data extends Omit<Meetup, "images"> {
+  sessions?: {
+    Session_id?: {
+      title?: string;
+      speakers?: {
+        name?: string;
+        github_account?: string;
+      }
+    }
+  }[];
+  sponsors?: {
+    Sponsor_id?: {
+      Name?: string;
+      Website?: string;
+    }
+  }[];
+  images?: {
+    imagename?: string;
+  }[];
+}
+
+interface Response {
+  data: Data[];
+}
+
+let response: Response = await loadEvents();
+
+const getSponsorDetails = (sponsors: Data["sponsors"]) => {
+  return sponsors?.map((sponsor) => ({
+    name: sponsor?.Sponsor_id?.Name || "",
+    url: sponsor?.Sponsor_id?.Website || ""
+  })) || [];
+}
+
+const getSessionsDetails = (sessions: Data["sessions"]) => {
+  return sessions?.map((session) => ({
+    title: session?.Session_id?.title || "",
+    speaker: session?.Session_id?.speakers?.name || "",
+    github_account: session?.Session_id?.speakers?.github_account || ""
+  })) || [];
+}
+
+const meetups = response.data.reduce((acc, event) => {
+  const year = new Date(event.Date).getFullYear();
+
+  if (!acc[year]) {
+    acc[year] = [];
+  }
+
+  acc[year].push({
+    title: event?.title || "",
+    location: event?.Location || "",
+    venue: event?.Venue || "",
+    time: event?.Time || "",
+    date: event?.Date || "",
+    images: event?.images?.map(image => image?.imagename || "") || [],
+    number_of_attendees: event?.Attendees || 0,
+    topics: getSessionsDetails(event?.sessions || []),
+    sponsors: getSponsorDetails(event?.sponsors || []),
+    live_url: `${SITE_URL}/meetup/${event?.id || ""}`
+  });
+
+  return acc;
+}, {});
+
+
+// response from this api looks as follows
+// grouped by year and each meantup has the following details:
+// title
+// location
+// venue
+// time
+// date -> YYYY-MM-DD,
+// images -> [] of image urls
+// number_of_attendees
+// topics -> [] of { title, speaker, github_account }
+// sponsors -> [] of { name, url }
+// live_url
+export const get: APIRoute = async () => {
+  return ({
+    body: JSON.stringify({
+      ...meetups
+    })
+  });
+}

--- a/src/pages/api/team.json.ts
+++ b/src/pages/api/team.json.ts
@@ -1,0 +1,22 @@
+import type { APIRoute } from 'astro';
+
+import { loadSpeakers } from "@utils/api";
+
+// can replace this with list of contributors from
+// https://api.github.com/repos/Front-End-Coders-Mauritius/frontendmu-astro/contributors
+import contributors from "../../data/contributors.json";
+
+import { people } from "../../components/Team.astro";
+
+const speakers = await loadSpeakers();
+
+
+export const get: APIRoute = async () => {
+  return ({
+    body: JSON.stringify({
+      people,
+      speakers: speakers.data.map(({name, github_account}) => ({name, github_account})),
+      contributors
+    })
+  });
+}


### PR DESCRIPTION
Easily available data is nice to have.

Added JSON api endpoints to get all team members, speakers and contributors.
Added JSON api endpoints to get all meetups detail

Implementation was based on top of current API called being made to populate the team and meetups pages. Data was cleaned a little bit

Routes:
Entry - /api/entry.json
Team - /api/team.json
Meetups - /api/meetups.json

Responses look like this:

1. Entry
```
{
  "api_routes": {
    "team": "http://localhost:3000/api/team.json",
    "meetups": "http://localhost:3000/api/meetups.json"
  }
}
```

2. Team

<img width="726" alt="Screenshot 2023-08-13 at 22 58 58" src="https://github.com/Front-End-Coders-Mauritius/frontendmu-astro/assets/88334281/3fa07b24-c173-46c3-a355-c0b2a8ae2311">


3. Meetups

<img width="726" alt="Screenshot 2023-08-13 at 22 58 33" src="https://github.com/Front-End-Coders-Mauritius/frontendmu-astro/assets/88334281/c369ae8f-28f9-457d-862c-7774960b1634">



House Keeping:

1. Added a link in footer to point to api route

<img width="422" alt="Screenshot 2023-08-13 at 23 01 26" src="https://github.com/Front-End-Coders-Mauritius/frontendmu-astro/assets/88334281/9387301e-ed06-4637-bbe5-5d9ceb58547f">

4. Added conditional site url based on whether we're in prod or dev mode. see astro configs. So, locally our base url is localhost and on prod it's the frontend.mu


