### PR TITLE
ADD Dynamic URL For Vercel Preview + Dev Envs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,9 +6,16 @@ import Icons from 'unplugin-icons/vite'
 
 import vue from "@astrojs/vue";
 
+let site = "https://frontend.mu";
+
+// https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables
+if (process.env.VERCEL_ENV === "preview" || process.env.VERCEL_ENV === "development") {
+  site = `https://${process.env.VERCEL_URL}`;
+}
+
 // https://astro.build/config
 export default defineConfig({
-  site: "https://frontend.mu",
+  site,
   integrations: [
     mdx(),
     sitemap(),


### PR DESCRIPTION
Jumping off #79 

Found a way to get dynamic urls from Vercel. This should affect the sitemap + endpoints URLS for Vercel previews and staging envs. 

See [vercel doc on system env variables](https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables) for more info.

Awaiting preview deploy to check if ok.