### PR TITLE
Add Entrepreneur value to the list of profession options

### DIFF
--- a/src/components/auth/constants.ts
+++ b/src/components/auth/constants.ts
@@ -15,6 +15,7 @@ import IconStudent from "~icons/ph/student";
 import IconManager from "~icons/material-symbols/person-celebrate-rounded";
 import IconDesigner from "~icons/ph/paint-brush-duotone";
 import IconHr from "~icons/mdi/briefcase-account";
+import IconEntrepreneur from "~icons/mdi/head-cog-outline";
 
 import type { Meal, Occupation, Transport } from "@utils/types";
 
@@ -30,6 +31,7 @@ export const professionOptions = [
     { value: "manager", name: "Manager", icon: IconManager },
     { value: "designer", name: "Designer", icon: IconDesigner },
     { value: "hr", name: "Hr", icon: IconHr },
+    { value: "entrepreneur", name: "Entrepreneur", icon: IconEntrepreneur },
     { value: "other", name: "Other", icon: IconHr },
 ] as { value: Occupation, name: string, icon: astroHTML.JSX.Element }[];
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -189,7 +189,7 @@ export type Meal = "veg" | "non_veg" | "no_food"
 
 export type Transport = "bus" | "car" | "need_a_ride" | "other"
 
-export type Occupation = "developer" | "student" | "manager" | "designer" | "hr" | "other"
+export type Occupation = "developer" | "student" | "manager" | "designer" | "hr" | "entrepreneur" | "other"
 
 export type RSVPMetaData = {
     meal: Meal


### PR DESCRIPTION
Ticket: https://github.com/Front-End-Coders-Mauritius/frontendmu-astro/issues/130

I've tested the changes:

- Browser: Brave
- OS: Windows 11
- Responsive screens

Checklist:

- [x] Added "Entrepreneur" value in the right place
- [x] Tested on normal screens
- [x] Tested on tablet-size screens
- [x] Tested on small screens

Full screen:
![image](https://github.com/Front-End-Coders-Mauritius/frontendmu-astro/assets/1567363/73be0fbd-864d-4192-b688-d9ab08806113)


Tablet:
![image](https://github.com/Front-End-Coders-Mauritius/frontendmu-astro/assets/1567363/3cd524d2-c540-41f1-aa68-e018fefe5985)

Small screen:
![image](https://github.com/Front-End-Coders-Mauritius/frontendmu-astro/assets/1567363/d891daee-ae75-43d9-8474-66ee7ab10187)

